### PR TITLE
#42 instantiate gamessession with applicationContext instead of new

### DIFF
--- a/mindbug-backend/src/main/java/com/mindbug/services/GameSession.java
+++ b/mindbug-backend/src/main/java/com/mindbug/services/GameSession.java
@@ -3,10 +3,13 @@ package com.mindbug.services;
 import com.mindbug.models.Game;
 import com.mindbug.services.wsmessages.WSMessageNewGame;
 import com.mindbug.websocket.WSMessageManager;
+
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 
 @Component
+@Scope("prototype")
 public class GameSession {
     private Game game;
 
@@ -19,12 +22,10 @@ public class GameSession {
     private GameStatus status = GameStatus.NOT_STARTED;
 
     
-    public GameSession(WSMessageManager gameWsMessageManager) {
-        this.gameWsMessageManager = gameWsMessageManager;
-    }
-
-    public void initialize(Game game) {
+    public GameSession(Game game, WSMessageManager gameWsMessageManager) {
         this.game = game;
+        
+        this.gameWsMessageManager = gameWsMessageManager;
         this.wsChannel = "/topic/game/" + game.getId();
         this.gameWsMessageManager.setChannel(wsChannel);
     }

--- a/mindbug-backend/src/main/java/com/mindbug/services/GameSessionFactory.java
+++ b/mindbug-backend/src/main/java/com/mindbug/services/GameSessionFactory.java
@@ -1,6 +1,7 @@
 package com.mindbug.services;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 
 import com.mindbug.models.Game;
@@ -8,12 +9,13 @@ import com.mindbug.websocket.WSMessageManager;
 
 @Service
 public class GameSessionFactory {
+    
     @Autowired
-    private WSMessageManager wsMessageManager;
+    private  ApplicationContext applicationContext;
     
     public GameSession createGameSession(Game game) {
-        GameSession gameSession = new GameSession(wsMessageManager);
-        gameSession.initialize(game);
+        GameSession gameSession = this.applicationContext.getBean(GameSession.class, game, 
+        this.applicationContext.getBean(WSMessageManager.class));
         return gameSession;
     }
 }


### PR DESCRIPTION
## Description
J'ai corrigé le fait qu'on instantie gamessession avec new

## Issue liée
Clôture #42

## Critères de la Definition of Done (DoD)

- [x] **Respect des critères d'acceptation** : La user story satisfait tous les critères d'acceptation définis dans la Définition of Ready (DoR) sans exceptions.
- [x] **Code complet** : Le code développé respecte les spécifications de la user story et suit les bonnes pratiques de développement en termes de structure, de lisibilité et de maintenabilité.
- [x] **Branche prête à être mergée** : Le code a été rebasé sur la dernière version de la branche principale (main) et est sans conflit (sur Github). Il a passé toutes les étapes de vérification automatique (tests, etc.) et l’arborescence de commits est propre (commits squashés si nécessaire).
- [x] **Intégration continue validée** : Le code a été testé automatiquement via l'intégration continue pour vérifier qu'il n'introduit pas de régressions ni de bugs, en respectant les tests de non-régression.
- [x] **Tests unitaires écrits et validés** : Les tests unitaires couvrant les fonctionnalités implémentées ont été écrits et passent avec succès.
- [x] **Revue de code effectuée** : Le code a été relu et validé par un ou plusieurs membres de l'équipe via une pull request. La participation du PO à la revue de code peut être sollicitée si nécessaire pour s'assurer que la solution répond bien aux attentes fonctionnelles.  Il faut au moins une validation d’un reviewer avant de fusionner la PR.
- [x] **Qualité du code** : Le code respecte les conventions de codage définies par l'équipe, validées à l'aide d'outils d'analyse statique (linters, etc.) pour s'assurer de la qualité du code.
- [x] **Documentation mise à jour** : Toute documentation technique ou fonctionnelle nécessaire a été créée ou mise à jour pour refléter les changements apportés dans le code.

## À valider par

@elcirdec 

## Instructions supplémentaires
Ajoutez des informations spécifiques si nécessaire, comme des instructions pour tester les changements ou des explications supplémentaires pour la revue de code.

